### PR TITLE
db is nil

### DIFF
--- a/internal/nocalhost-api/model/init.go
+++ b/internal/nocalhost-api/model/init.go
@@ -51,6 +51,7 @@ func openDB(username, password, addr, name string) *gorm.DB {
 	db, err := gorm.Open("mysql", config)
 	if err != nil {
 		log.Errorf("Database connection failed. Database name: %s, err: %+v", name, err)
+		panic(err)
 	}
 
 	db.Set("gorm:table_options", "CHARSET=utf8mb4")


### PR DESCRIPTION
```bash
$ k get po
NAME                             READY   STATUS             RESTARTS   AGE
nocalhost-api-66f9fff696-mdp5c   0/1     CrashLoopBackOff   14         47m
nocalhost-mariadb-0              0/1     Pending            0          47m
nocalhost-web-5654446744-zkt5h   1/1     Running            0          47m
```

api logs 
```text
panic: runtime error: invalid memory address or nil pointer dereference
```

db is nil