### PR TITLE
db is nil

### DIFF
--- a/internal/nocalhost-api/model/init.go
+++ b/internal/nocalhost-api/model/init.go
@@ -51,6 +51,7 @@ func openDB(username, password, addr, name string) *gorm.DB {
 	db, err := gorm.Open("mysql", config)
 	if err != nil {
 		log.Errorf("Database connection failed. Database name: %s, err: %+v", name, err)
+		panic(err)
 	}
 
 	db.Set("gorm:table_options", "CHARSET=utf8mb4")


### PR DESCRIPTION
```bash
$ k get po
NAME                             READY   STATUS             RESTARTS   AGE
nocalhost-api-66f9fff696-mdp5c   0/1     CrashLoopBackOff   14         47m
nocalhost-mariadb-0              0/1     Pending            0          47m
nocalhost-web-5654446744-zkt5h   1/1     Running            0          47m
```

api logs

```bash
$ k logs -f nocalhost-api-66f9fff696-mdp5c

```

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xb46700]

goroutine 1 [running]:
nocalhost/pkg/nocalhost-api/pkg/log.Errorf(...)
	/opt/src/pkg/nocalhost-api/pkg/log/logger.go:121
nocalhost/internal/nocalhost-api/model.openDB(0xc0007641c8, 0x4, 0xc0007641e0, 0x4, 0xc00010a3c0, 0x16, 0xc0007641a0, 0x9, 0x0)
	/opt/src/internal/nocalhost-api/model/init.go:53 +0x4c0
nocalhost/internal/nocalhost-api/model.Init(0x1c02260)
	/opt/src/internal/nocalhost-api/model/init.go:34 +0x14d
nocalhost/pkg/nocalhost-api/napp.New(0xc000720680, 0x17)
	/opt/src/pkg/nocalhost-api/napp/app.go:62 +0x4e
main.main()
	/opt/src/cmd/nocalhost-api/nocalhost-api.go:71 +0x339
```