### PR TITLE
fix(api): error with cluster is not initialized

### DIFF
--- a/pkg/nocalhost-api/app/api/v1/cluster_user/v2_list.go
+++ b/pkg/nocalhost-api/app/api/v1/cluster_user/v2_list.go
@@ -100,6 +100,11 @@ func ListV2(c *gin.Context) {
 	}
 
 	if result, err := DoList(&cu, userId, isAdmin, params.IsCanBeUsedAsBaseSpace); err != nil {
+		if err == errno.ErrClusterNotFound {
+			log.Error(err)
+			api.SendResponse(c, nil, []model.ClusterUserV2{})
+			return
+		}
 		api.SendResponse(c, err, nil)
 	} else {
 		api.SendResponse(c, nil, result)


### PR DESCRIPTION
web ui get the error info "Cluster has not found", when the cluster is not initialized