### PR TITLE
fix: db config should have higher priority than mariadb

### DIFF
--- a/deployments/chart/templates/db-init-configmap.yaml
+++ b/deployments/chart/templates/db-init-configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nocalhost-api-sql-init-config
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-10"
 data:
   nocalhost.sql: |-
 {{ .Files.Get "sql/nocalhost-api.sql" | indent 4 }}


### PR DESCRIPTION
The default weight of mariadb is 1.

Signed-off-by: Yicai Yu <yuyicai@hotmail.com>