### PR TITLE
bug: keep Pod Template annotations when PatchDevModeManifest

### DIFF
--- a/internal/nhctl/controller/service.go
+++ b/internal/nhctl/controller/service.go
@@ -364,7 +364,7 @@ func (c *Controller) PatchDevModeManifest(ctx context.Context, ops *model.DevSta
 			jsonPatches, jsonPatch{
 				Op:    "replace",
 				Path:  specPath,
-				Value: c.getDevContainerAnnotations(ops.Container, map[string]string{}),
+				Value: c.getDevContainerAnnotations(ops.Container, podTemplate.GetAnnotations()),
 			},
 		)
 		bys, _ = json.Marshal(jsonPatches)


### PR DESCRIPTION
**What this PR does / why we need it**:

PodTemplate annotations include some network config in our k8s cluster;

**Special notes for your reviewer**:

patch action shuld only add new annotation not replace it ;

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
