### PR TITLE
fix(ci): change github images repository to ghcr.io

### DIFF
--- a/.github/workflows/api-docker.yml
+++ b/.github/workflows/api-docker.yml
@@ -24,30 +24,34 @@ jobs:
         env:
           SERVICE_INITIAL: true
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-api
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-api
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker push ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
 
       - name: Push main to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-api
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-api
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:main
           docker push ${GITHUB_IMAGE_NAME}:main
 
       - name: Push dev to Github packages
         if: ${{ github.ref == 'refs/heads/dev'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-api
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-api
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:dev
           docker push ${GITHUB_IMAGE_NAME}:dev
 

--- a/.github/workflows/dep-docker.yml
+++ b/.github/workflows/dep-docker.yml
@@ -17,21 +17,26 @@ jobs:
       - name: Build dep-docker
         run: make dep-docker
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-dep
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-dep
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-dep:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker push ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
 
       - name: Push latest to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-dep
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-dep
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-dep:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:latest
           docker push ${GITHUB_IMAGE_NAME}:latest
 

--- a/.github/workflows/dep-installer-job-docker.yml
+++ b/.github/workflows/dep-installer-job-docker.yml
@@ -20,18 +20,16 @@ jobs:
       - name: Push to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/dep-installer-job
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/dep-installer-job
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag dep-installer-job:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker push ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
 
       - name: Push latest to Github packages
         if: ${{ github.ref == 'refs/heads/main'}}
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/dep-installer-job
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/dep-installer-job
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag dep-installer-job:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:latest
           docker push ${GITHUB_IMAGE_NAME}:latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,11 +265,17 @@ jobs:
           SERVICE_INITIAL: true
         run: make api-docker
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to Github packages
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-api
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-api
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:latest
           docker tag nocalhost-api:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${{ env.RELEASE_VERSION }}
@@ -294,9 +300,8 @@ jobs:
 
       - name: Push to Github packages
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/nocalhost-dep
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/nocalhost-dep
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag nocalhost-dep:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker tag nocalhost-dep:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:latest
           docker tag nocalhost-dep:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${{ env.RELEASE_VERSION }}
@@ -323,9 +328,8 @@ jobs:
 
       - name: Push to Github packages
         env:
-          GITHUB_IMAGE_NAME: docker.pkg.github.com/${{ github.repository }}/dep-installer-job
+          GITHUB_IMAGE_NAME: ghcr.io/nocalhost/nocalhost/dep-installer-job
         run: |
-          echo ${{ secrets.GPR_PASS }} | docker login docker.pkg.github.com -u ${{ secrets.GPR_USER }} --password-stdin
           docker tag dep-installer-job:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${GITHUB_SHA}
           docker tag dep-installer-job:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:latest
           docker tag dep-installer-job:${GITHUB_SHA} ${GITHUB_IMAGE_NAME}:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR: https://github.com/nocalhost/nocalhost/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

change `docker.pkg.github.com` to `ghcr.io`
>GitHub's Docker registry (which used the namespace docker.pkg.github.com) has been replaced by the Container registry (which uses the namespace https://ghcr.io).

more info, see: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry


**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
